### PR TITLE
Adding Query Optimization on calendar module

### DIFF
--- a/app/models/decidim/calendar/event.rb
+++ b/app/models/decidim/calendar/event.rb
@@ -4,9 +4,9 @@ module Decidim
   module Calendar
     module Event
       @models = [
-        Decidim::Meetings::Meeting,
+        Decidim::Meetings::Meeting.includes(component: :participatory_space),
         Decidim::ParticipatoryProcessStep,
-        Decidim::Debates::Debate,
+        Decidim::Debates::Debate.includes(component: :participatory_space),
         Decidim::Calendar::ExternalEvent
       ]
 


### PR DESCRIPTION
Avoid N+1 Queries when accessing the calendar module.